### PR TITLE
Implement: add more personas and role checklists to project management docs

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,3 +1,4 @@
+```markdown
 # OctoAcme Personas
 
 This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
@@ -75,7 +76,205 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## Additional Personas (proposed additions)
+
+### DevOps / SRE
+
+#### Role Summary
+Manage production readiness, CI/CD, deployments, and system reliability.
+
+#### Responsibilities
+- Maintain CI/CD pipelines and deployment automation
+- Operate monitoring, alerting, and runbooks
+- Ensure infrastructure-as-code and environment parity
+- Participate in incident response and post-incident reviews
+- Optimize operational cost and performance
+
+#### Goals
+- Keep services reliable and observable
+- Reduce mean time to recovery (MTTR)
+- Automate repeatable operational tasks
+
+#### Typical Communication / Interactions
+- Works with Developers to onboard services and pipelines
+- Coordinates with Project Manager/Release Manager for deployment windows
+- Collaborates with QA on staging verification
+- Escalates production incidents to PM and Product Lead
+
+---
+
+### Security Engineer
+
+#### Role Summary
+Ensure secure design and operations across the project lifecycle.
+
+#### Responsibilities
+- Conduct threat modeling and security reviews
+- Implement and maintain automated security scans in CI
+- Triage and advise on vulnerabilities
+- Define security acceptance criteria for features
+- Provide guidance on authentication, authorization, and data protection
+
+#### Goals
+- Reduce security risk and exposure
+- Ensure secure-by-default design decisions
+
+#### Typical Communication / Interactions
+- Reviews designs with Developers and Product Manager
+- Works with DevOps to integrate security gates into CI/CD
+- Notifies PM and stakeholders of security risks and mitigation plans
+
+---
+
+### UX Researcher / Product Designer
+
+#### Role Summary
+Validate product decisions through research and design; ensure usability and accessibility.
+
+#### Responsibilities
+- Conduct user research and usability testing
+- Create journey maps, wireframes, and prototypes
+- Define UX acceptance criteria
+- Provide design specs and accessibility guidance
+
+#### Goals
+- Improve usability and user satisfaction
+- Ensure designs meet accessibility and business goals
+
+#### Typical Communication / Interactions
+- Partners with Product Manager on user needs and success metrics
+- Hands off designs to Developers and collaborates on feasibility
+- Works with QA on usability testing and acceptance
+
+---
+
+### Data Analyst / BI
+
+#### Role Summary
+Define measurement strategy, instrument events, and analyze outcomes to inform decisions.
+
+#### Responsibilities
+- Define key metrics and tracking plans
+- Implement or validate analytics instrumentation
+- Create dashboards and reports
+- Analyze release impact and user behavior
+
+#### Goals
+- Ensure data-driven decision making
+- Measure and communicate outcomes against success criteria
+
+#### Typical Communication / Interactions
+- Partners with Product Manager to define success metrics
+- Works with Developers and DevOps to implement instrumentation
+- Shares findings with stakeholders and integrates learnings into planning
+
+---
+
+### Technical Writer / Documentation Owner
+
+#### Role Summary
+Produce and maintain user-facing and operational documentation.
+
+#### Responsibilities
+- Write release notes, API docs, runbooks, and onboarding guides
+- Ensure documentation is updated prior to release
+- Maintain a documentation review process
+
+#### Goals
+- Reduce user and support friction with clear documentation
+- Keep runbooks current for on-call responders
+
+#### Typical Communication / Interactions
+- Receives feature summaries from Product Manager and Developers
+- Works with Release Manager on release notes
+- Coordinates with Support for knowledge-base updates
+
+---
+
+### Release Manager
+
+#### Role Summary
+Coordinate the release process end-to-end to ensure predictable, low-risk deployments.
+
+#### Responsibilities
+- Maintain release checklist and schedule
+- Confirm pre-release requirements (tests, docs, rollback plans)
+- Coordinate cross-team deployment activities
+- Communicate release status to stakeholders
+
+#### Goals
+- Reduce deployment-related incidents
+- Ensure coordinated, observable releases
+
+#### Typical Communication / Interactions
+- Works with DevOps/SRE to run staged deployments
+- Confirms readiness with QA, Product, and Technical Writer
+- Notifies PM and stakeholders of release outcomes
+
+---
+
+### Customer Success / Support Lead
+
+#### Role Summary
+Represent customer operational needs and handle post-release support.
+
+#### Responsibilities
+- Prepare support playbooks and triage guides
+- Triage and escalate customer issues
+- Feed customer feedback into the backlog
+
+#### Goals
+- Increase customer satisfaction and reduce time-to-resolution
+- Ensure customer-impacting issues are prioritized appropriately
+
+#### Typical Communication / Interactions
+- Engages with Product Manager for priority fixes
+- Works with Technical Writer to update KB articles
+- Coordinates with Developers for hotfixes and workarounds
+
+---
+
+### Legal / Compliance Advisor
+
+#### Role Summary
+Ensure features and processes comply with legal, regulatory, and contractual obligations.
+
+#### Responsibilities
+- Review features for compliance risk (PII, data residency, contracts)
+- Provide sign-off where required
+- Advise on retention, consent, and data-sharing policies
+
+#### Goals
+- Avoid legal and regulatory exposure
+- Ensure contractual commitments are met
+
+#### Typical Communication / Interactions
+- Consulted by Product Manager/PM during planning for compliance-impacting features
+- Coordinates with Security Engineer for technical controls
+
+---
+
+### Accessibility Specialist
+
+#### Role Summary
+Help ensure that features meet accessibility standards and are testable.
+
+#### Responsibilities
+- Run accessibility reviews and provide remediation guidance
+- Create accessibility acceptance criteria and tests
+- Provide training and best practices for designers and developers
+
+#### Goals
+- Deliver inclusive products that meet required standards (e.g., WCAG)
+- Reduce accessibility regressions in releases
+
+#### Typical Communication / Interactions
+- Works with Designers and Developers during design and implementation
+- Partners with QA to include accessibility checks in test plans
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-
+```

--- a/docs/role-responsibility-checklist.md
+++ b/docs/role-responsibility-checklist.md
@@ -1,0 +1,40 @@
+```markdown
+# Role & Responsibility Checklist (planning / release)
+
+Use this checklist during planning and pre-release to ensure owners are assigned and cross-cutting concerns are covered.
+
+## Before planning is complete
+- [ ] Product Manager identified and success metrics defined
+- [ ] Project Manager / Delivery lead assigned
+- [ ] Development owner(s) assigned
+- [ ] QA owner assigned and test approach agreed
+- [ ] DevOps/SRE contact identified for deployment & monitoring
+- [ ] Security contact identified (if feature touches sensitive data or auth)
+- [ ] UX/Design owner identified (if user-facing changes)
+- [ ] Data analyst / BI owner identified (if metrics/analytics required)
+- [ ] Technical writer / documentation owner identified
+- [ ] Accessibility specialist engaged (if applicable)
+- [ ] Legal / Compliance engaged (if applicable)
+- [ ] Customer Success / Support lead notified for post-release handling
+
+## Pre-release readiness (complete before scheduling deployment)
+- [ ] All acceptance criteria met
+- [ ] CI passing and security scans green
+- [ ] Observability/metrics instrumented and dashboard(s) prepared
+- [ ] Runbooks and on-call contact info updated
+- [ ] Documentation & release notes drafted and reviewed
+- [ ] Accessibility checks passed or known issues documented
+- [ ] Legal/compliance sign-off obtained (if required)
+- [ ] Release Manager confirmed deployment window and rollback plan
+- [ ] Support playbook prepared for known user-impact scenarios
+
+## Post-release
+- [ ] Post-deploy smoke tests executed and green
+- [ ] Monitoring for errors/latency reviewed within agreed window
+- [ ] Customer feedback / support tickets triaged and escalated as needed
+- [ ] Release outcome and metrics reported to stakeholders
+
+Notes:
+- If a role is not needed for a particular project, mark it as N/A and provide rationale.
+- Capturing owners explicitly reduces handoff friction and speeds decision making.
+```


### PR DESCRIPTION
Short summary of changes (update octoacme-roles-and-personas.md with additional personas; add role-responsibility-checklist.md)
Rationale: addresses gaps identified in issue #4 (link the issue). Improves clarity of ownership for cross-cutting concerns (security, release, docs, observability, accessibility, data).
Files changed list
Request review from @corina-teodora-coste
Link to issue: "Refs #4" (if you want the issue to remain open) or "Implements #4" (if you want PR to close the issue). Example PR body (copy/paste-ready):